### PR TITLE
Add dark mode css

### DIFF
--- a/assets/css/openloco.css
+++ b/assets/css/openloco.css
@@ -47,6 +47,7 @@
     }
     
     .masthead,
+    .archive__subtitle,
     .page__content h2 {
         border-bottom: 1px solid #424343;
     }

--- a/assets/css/openloco.css
+++ b/assets/css/openloco.css
@@ -1,1 +1,59 @@
 @-webkit-keyframes intro { } @keyframes intro { }
+
+@media (prefers-color-scheme: dark) {
+    
+    ::selection {
+      color: #fff;
+      background: #424343;
+    }
+    
+    body {
+        background: #222;
+        color: #eee;
+    }
+    
+    a {
+      color: #59d8ff;
+    }
+    
+    a:active,
+    a:hover {
+      color: #3f9db9;
+    }
+    
+    a:visited {
+      color: #59d8ff;
+    }
+
+    p>code,
+    a>code,
+    li>code,
+    figcaption>code,
+    td>code {
+      background:#4b4848;
+    }
+    
+    
+    .greedy-nav {
+        background: #222;
+    }
+    
+    .greedy-nav a {
+        color: #b3bfc8;
+    }
+    
+    .greedy-nav a:hover {
+        color: white;
+    }
+    
+    .masthead,
+    .page__content h2 {
+        border-bottom: 1px solid #424343;
+    }
+    
+    .page__footer {
+        background: #424343;
+        color: #eee;
+    } 
+        
+}

--- a/assets/css/openloco.css
+++ b/assets/css/openloco.css
@@ -50,6 +50,22 @@
     .page__content h2 {
         border-bottom: 1px solid #424343;
     }
+
+    .pagination li a {
+        border: 1px solid #424343;
+    }
+    
+    .pagination li a:hover {
+      color: #59d8ff;
+    }
+    .pagination li a.disabled {
+        color: rgba(100,103,105,0.9);
+    }
+    
+    .pagination li a.current, .pagination li a.current.disabled {
+      color: #fff;
+      background: #424343;
+    }
     
     .page__footer {
         background: #424343;

--- a/assets/css/openloco.css
+++ b/assets/css/openloco.css
@@ -72,5 +72,12 @@
         background: #424343;
         color: #eee;
     } 
+
+    .social-icons .fas, .social-icons .fab, .social-icons .far, .social-icons .fal {
+        color: white;
+    }
+    .social-icons .fa-rss, .social-icons .fa-rss-square {
+        color: #fa9b39;
+    }
         
 }


### PR DESCRIPTION
Add support for the browser preference of dark mode for sites. If the browser is set to prefer dark mode, the site will be automatically shown in dark mode  
As proposed in issue #5 